### PR TITLE
Update 2015-02-12-io-js-and-node-js-foundation.md

### DIFF
--- a/source/_posts/2015-02-12-io-js-and-node-js-foundation.md
+++ b/source/_posts/2015-02-12-io-js-and-node-js-foundation.md
@@ -1,4 +1,4 @@
-title: io.js 和 a node.js 基金會
+title: io.js 和 node.js 基金會
 date: 2015-02-12 20:46:25
 tags:
 categories: iojs 好文


### PR DESCRIPTION
標題的 'a' 翻中文之後應該不用特別打出來?
語意怪怪的
